### PR TITLE
Add timeout to the flip method to avoid instant flip when move to top…

### DIFF
--- a/src/components/DrillCard.jsx
+++ b/src/components/DrillCard.jsx
@@ -26,6 +26,9 @@ export default function DrillCard({ word, switchAll, moveCardToEnd, moveCardToTo
   }, [switchAll]);
 
   const handleFlipped = () => {
+    setTimeout(() => {
+      setFlipped((prev) => !prev);
+    }, 300);
     setFlipped((prev) => !prev);
   };
 


### PR DESCRIPTION
… or move to end list